### PR TITLE
Use structopt instead of clap for parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,11 +45,11 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 name = "bopus"
 version = "0.1.0"
 dependencies = [
- "clap",
  "execute",
  "num_cpus",
  "rayon",
  "regex",
+ "structopt",
  "threadpool",
 ]
 
@@ -180,6 +180,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +239,30 @@ name = "once_cell"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -305,6 +338,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "structopt"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +404,12 @@ name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "2.33"
+structopt = "0.3.21"
 execute = "0.2.8"
 regex = "1.4.3"
 threadpool = "1.8.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,7 +202,7 @@ fn optimize(file: &DirEntry, target_quality: f32) {
     cmd.output().unwrap();
 }
 
-fn segment(input: &Path) -> Vec<std::result::Result<DirEntry, std::io::Error>> {
+fn segment(input: &Path) -> Vec<Result<DirEntry, std::io::Error>> {
     let segments = Path::new("temp/segments");
     let mut cmd = Command::new("ffmpeg");
     cmd.args(&[

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,7 +171,7 @@ fn optimize(file: &DirEntry, target_quality: f32) {
         }
         let pf = file.path();
         score = make_probe(pf, bitrate);
-        score = trasnform_score(score);
+        score = transform_score(score);
         bitrates.push((bitrate, score));
 
         let dif: f32 = (score - target_quality).abs();
@@ -230,7 +230,7 @@ fn segment(input: &Path) -> Vec<Result<DirEntry, std::io::Error>> {
 
 /// Transform score for easier score comprehension and usage
 /// Scaled 4.0 - 4.75 range to 0.0 - 5.0
-fn trasnform_score(score: f32) -> f32 {
+fn transform_score(score: f32) -> f32 {
     if score < 4.1 {
         return 1.0f32;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use structopt::StructOpt;
 
 /// Opus bitrate optimizer
 #[derive(StructOpt, Debug)]
-#[structopt(author = "Zen <true.grenight@gmail.com>>")]
+#[structopt(author)]
 struct Args {
     /// Input file to use
     #[structopt(short, long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,22 +1,37 @@
-extern crate execute;
-extern crate num_cpus;
-extern crate regex;
-extern crate threadpool;
-use clap::{App, Arg};
 use rayon::prelude::*;
 use regex::Regex;
+
 use std::cmp;
 use std::env;
 use std::fs;
-use std::fs::DirEntry;
-use std::fs::File;
+use std::fs::{DirEntry, File};
 use std::io::prelude::*;
-use std::path::Path;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
+use structopt::StructOpt;
+
+/// Opus bitrate optimizer
+#[derive(StructOpt, Debug)]
+#[structopt(author = "Zen <true.grenight@gmail.com>>")]
+struct Args {
+    /// Input file to use
+    #[structopt(short, long)]
+    input: PathBuf,
+
+    /// Value of quality to target
+    #[structopt(short, long = "target", default_value = "4.0")]
+    target_quality: f32,
+
+    /// Number of jobs to run
+    #[structopt(short, long)]
+    jobs: Option<usize>,
+}
+
 fn main() {
-    // check if executables exist
+    let args = Args::from_args();
+
+    // check if executables exist after getting CLI args
     if !is_program_in_path("ffmpeg") {
         println!("No.");
     }
@@ -25,60 +40,22 @@ fn main() {
         println!("No.");
     }
 
-    // arg parsing
-    let _matches = App::new("Bopus")
-        .version("0.1")
-        .author("Zen <true.grenight@gmail.com>>")
-        .about("Opus bitrate optimizer")
-        .arg(
-            Arg::with_name("INPUT")
-                .short("i")
-                .long("input")
-                .value_name("INPUT")
-                .help("Sets the input file to use")
-                .required(true)
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("TARGET")
-                .short("t")
-                .long("target")
-                .help("Sets value of quality to target")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("JOBS")
-                .short("j")
-                .long("jobs")
-                .help("set amount of jobs to run")
-                .takes_value(true),
-        )
-        .get_matches();
-
     // Create all required temp dirs
     create_all_dir();
 
-    let input_file: &str = _matches.value_of("INPUT").unwrap();
-    let target_quality: f32 = _matches.value_of("TARGET").unwrap_or("4").parse().unwrap();
-
-    let cpu_cores: i32 = (num_cpus::get() / 2) as i32;
-    let mut jobs: i32 = _matches
-        .value_of("JOBS")
-        .unwrap_or(&format!("{}", cpu_cores))
-        .parse()
-        .unwrap();
+    let mut jobs = args.jobs.unwrap_or_else(|| num_cpus::get() / 2);
 
     // printing some stuff
-    println!(":: Using input file {}", input_file);
-    println!(":: Using target quality {}", target_quality);
+    println!(":: Using input file {:?}", args.input);
+    println!(":: Using target quality {}", args.target_quality);
 
     // making wav and segmenting
-    let wav_segments = segment(input_file);
+    let wav_segments = segment(&args.input);
     let mut it = vec![];
     for seg in wav_segments {
         it.push(seg.unwrap())
     }
-    jobs = cmp::min(jobs, it.len() as i32);
+    jobs = cmp::min(jobs, it.len());
 
     println!(":: Segments {}", it.len());
     println!(":: Running {} jobs", jobs);
@@ -88,9 +65,9 @@ fn main() {
         .build_global()
         .unwrap();
 
-    it.par_iter().for_each(move |x| optimize(x, target_quality));
+    it.par_iter().for_each(|x| optimize(x, args.target_quality));
 
-    concatenate(input_file);
+    concatenate(&args.input);
 }
 
 fn create_all_dir() {
@@ -129,7 +106,7 @@ fn create_all_dir() {
     }
 }
 
-fn concatenate(output: &str) {
+fn concatenate(output: &Path) {
     println!(":: Concatenating");
     let conc_file = Path::new("temp/concat.txt");
     let conc_folder = Path::new("temp/conc");
@@ -161,12 +138,12 @@ fn concatenate(output: &str) {
         "-f",
         "concat",
         "-i",
-        conc_file.to_str().unwrap(),
+        conc_file.to_str().expect("Filename is not valid UTF-8"),
         "-c",
         "copy",
         out,
     ]);
-    //println!("{:?}", cmd);
+
     cmd.output().expect("Failed to concatenate");
 }
 
@@ -225,13 +202,15 @@ fn optimize(file: &DirEntry, target_quality: f32) {
     cmd.output().unwrap();
 }
 
-fn segment(input: &str) -> Vec<std::result::Result<DirEntry, std::io::Error>> {
+fn segment(input: &Path) -> Vec<std::result::Result<DirEntry, std::io::Error>> {
     let segments = Path::new("temp/segments");
     let mut cmd = Command::new("ffmpeg");
     cmd.args(&[
         "-y",
         "-i",
-        input,
+        // TODO check if filename can be written as a UTF-8 string, or escape
+        // the chars when passing to ffmpeg when it isn't
+        input.to_str().expect("Filename is not valid UTF-8"),
         "-ar",
         "48000",
         "-f",

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,11 +33,11 @@ fn main() {
 
     // check if executables exist after getting CLI args
     if !is_program_in_path("ffmpeg") {
-        println!("No.");
+        println!("FFmpeg is not installed or in PATH, required for encoding audio");
     }
 
     if !is_program_in_path("visqol") {
-        println!("No.");
+        println!("visqol is not installed or in PATH, required for perceptual quality metrics");
     }
 
     // Create all required temp dirs


### PR DESCRIPTION
Structopt is a lot more ergonomic then using clap directly, all you have to do is define a struct with some properties and it will automatically generate all the parsing logic for all the fields, and you don't have to call `.unwrap()` manually.

Also changed some functions to take a `&Path` as an argument instead of a `&str` -- this is because strings in rust have to be valid UTF-8, but filenames in operating systems aren't always valid UTF-8.

Removed use of `extern crate`, they were necessary in rust 2015 edition but are not necessary any more in rust 2018.

Changed `jobs` field in CLI argument to be a `usize` -- that is, an unsigned integer whose size depends on the pointer size of the operating system. This makes more sense than an `i32` (signed 32 bit integer), as the number of CPU cores should always be positive.